### PR TITLE
Remove nori2 import

### DIFF
--- a/data/unpack_msgpack_data.py
+++ b/data/unpack_msgpack_data.py
@@ -2,7 +2,6 @@ import io
 
 import cv2
 import numpy as np
-import nori2 as nori
 import msgpack
 import config
 import os


### PR DESCRIPTION
Remove nori2 import, since it causes errors, and won't be supported according to this comment
https://github.com/Megvii-CSG/MegReader/issues/11#issuecomment-567866231